### PR TITLE
Bugfix: TrackArchive invalid UUID preventing app startup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ after_script:
   - ./gradlew signingReport
 
 before_deploy:
-  - cp app/build/outputs/apk/app-bintray.apk app/build/outputs/apk/ibis-app-$(date +%Y-%m-%d_%H-%M-%S)-$TRAVIS_BRANCH-$TRAVIS_COMMIT.apk
+  - TRAVIS_BRANCH_ESCAPED=$(echo "$TRAVIS_BRANCH" | sed -r 's/[/]+/-/g')
+  - cp app/build/outputs/apk/app-bintray.apk app/build/outputs/apk/ibis-app-$(date +%Y-%m-%d_%H-%M-%S)-$TRAVIS_BRANCH_ESCAPED-$TRAVIS_COMMIT.apk
 
 deploy:
   - provider: bintray

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,4 @@ deploy:
     key:
       secure: K5zoytQcAcc4fmf1hvZ+GOqxQEbBdteT+rOtXKAYyJk99W0YCeP9Huh9imF+h84LZQcN32O8Hhrl1pdjKcVMiCO8gf0zrA5TiG6JMUctv1qmlkz5uxO3Y/M8NSrhCstG0Oi8I8p9swvyZY3gRDdhjhwbvn4CaHa0B/Vu7DP85sQDvveMc7ynxKPZOljC23iBfRsvCA/nQm+2TfM/M4AnxxBM9s/ogQggbDVDxfrw0tAXHkFR1bgEHzSvdcNFOt7YwYOs4CAqGfWSEruzMbVYKclAzXTQ1RYEuK6Isu1H5PUZICkvP1c3uIarz6J2qsH/+AsiI+Fa8vOcizmT52MnK+nvIK9+JpSm6XoAcEnsb8kF4xna2wZp7jJQlS5Qb0/hcd3TJyiTqrlJBwvEfS6X8JoozJNErVLkYTLSbBcgcKopMamoA1l5Cng6tFLdlMaV+xMbZhjp7HtBMJLp6zjzHeWXE6e8LwP6grtuB8wIDKZxZjmMAOk0JIrvxOhHMuDqpbsnlLmT7gj1Ia1eFF5ApVn3ms2P8MXyh3bbXAqkaCL9VV1e22BesdC/2KYlOKmGTs8EDPwgjTy/mfF7Bzca2KpY6fP/McP5djgDm8LtBdZVRq9pHQWDZtgCed7ihF3mek/KRXG+ijhfQTtz30u3rnWWEI5gWOiRlyR/yBR1p7A=
     on:
-      branch:
-        - master
-        - develop
-        - /^bugfix.*$/
+      all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ branches:
   only:
     - master
     - develop
+    - /^bugfix.*$/
 
 android:
   components:
@@ -48,3 +49,4 @@ deploy:
       branch:
         - master
         - develop
+        - /^bugfix.*$/

--- a/app/src/main/java/de/mytfg/jufo/ibis/storage/IbisTrackArchive.java
+++ b/app/src/main/java/de/mytfg/jufo/ibis/storage/IbisTrackArchive.java
@@ -69,6 +69,9 @@ public class IbisTrackArchive {
             trackUuidList.ensureCapacity(trackUuidsAsStringArray.length);
             trackMetadataList.ensureCapacity(trackUuidsAsStringArray.length);
             for (String aTrack_names_string : trackUuidsAsStringArray) {
+                if (aTrack_names_string.isEmpty()) {
+                    continue;
+                }
                 // read track metadata from file for each track and put into trackMetadataList
                 try {
                     UUID uuid = UUID.fromString(aTrack_names_string);
@@ -94,6 +97,9 @@ public class IbisTrackArchive {
             String trackIdMap = sharedPrefs.getString(PREFS_TRACKIDMAPPING, "");
             String[] trackKeyValuesArray = trackIdMap.split(";");
             for (String trackKeyValue : trackKeyValuesArray) {
+                if (trackKeyValue.isEmpty()) {
+                    continue;
+                }
                 String[] trackKeyValueArray = trackKeyValue.split(":");
                 if(!trackKeyValueArray[0].isEmpty() && !trackKeyValueArray[1].isEmpty()) {
                     try {

--- a/app/src/main/java/de/mytfg/jufo/ibis/storage/IbisTrackArchive.java
+++ b/app/src/main/java/de/mytfg/jufo/ibis/storage/IbisTrackArchive.java
@@ -3,7 +3,6 @@ package de.mytfg.jufo.ibis.storage;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.support.annotation.Nullable;
-import android.widget.Toast;
 
 import org.acra.ACRA;
 
@@ -81,9 +80,7 @@ public class IbisTrackArchive {
                     trackMetadata.put(uuid, metadata);
                 }
                 catch (IllegalArgumentException e) {
-                    Toast.makeText(context, "Invalid UUID: " + aTrack_names_string,
-                            Toast.LENGTH_LONG).show();
-                    ACRA.getErrorReporter().putCustomData("PREFS_TRACKLIST", trackNameList);
+                    ACRA.getErrorReporter().putCustomData(PREFS_TRACKLIST, trackNameList);
                     ACRA.getErrorReporter().putCustomData("uuid", aTrack_names_string);
                     ACRA.getErrorReporter().handleException(e);
                 }
@@ -108,9 +105,7 @@ public class IbisTrackArchive {
                                 UUID.fromString(trackKeyValueArray[1])
                         );
                     } catch (IllegalArgumentException e) {
-                        Toast.makeText(context, "Invalid UUID Public-ID mapping: " + trackKeyValue,
-                                Toast.LENGTH_LONG).show();
-                        ACRA.getErrorReporter().putCustomData("PREFS_TRACKIDMAPPING", trackIdMap);
+                        ACRA.getErrorReporter().putCustomData(PREFS_TRACKIDMAPPING, trackIdMap);
                         ACRA.getErrorReporter().putCustomData("uuid-id-mapping", trackKeyValue);
                         ACRA.getErrorReporter().handleException(e);
                     }


### PR DESCRIPTION
IbisTrackArchive: reading track list/mapping from shared preferences: bugfix: check for empty strings before converting to UUID and catch potential ParseExceptions.

Addition:
- Travis CI: build (and upload to dl.bintray.com) `bugfix`\* branches.
