### PR TITLE
Track archive: rewrite to use sqlite for metadata

### DIFF
--- a/app/src/main/java/de/opencyclecompass/app/android/MapFragment.java
+++ b/app/src/main/java/de/opencyclecompass/app/android/MapFragment.java
@@ -148,7 +148,7 @@ public class MapFragment extends Fragment {
     private Polyline createPolylineFromDB(OcycoTrack lTDB, int color) {
         Log.i(TAG, "createDrivenPolyline()");
         //create waypoints Array
-        Log.i(TAG, "database size: " + lTDB.metaData.getNumberOfLocations() + " rows");
+        Log.i(TAG, "database size: " + lTDB.metadata.getNumberOfLocations() + " rows");
         Polyline polyline = new Polyline(getActivity().getApplicationContext());
         polyline.setColor(color);
         ArrayList<GeoPoint> waypoints = lTDB.getGeoPointArrayList();

--- a/app/src/main/java/de/opencyclecompass/app/android/RoutingActivity.java
+++ b/app/src/main/java/de/opencyclecompass/app/android/RoutingActivity.java
@@ -541,7 +541,7 @@ public class RoutingActivity extends AppCompatActivity implements TimePickerFrag
                     //read and insert points from jArrray
                     mRDB.appendJsonLocationArray(jArray);
                     //get total dist, convert to km an round
-                    double totalDist = mRDB.metaData.getTotalDistance() / 1000;
+                    double totalDist = mRDB.metadata.getTotalDistance() / 1000;
                     String totalDistRounded = roundDecimals(totalDist);
                     //show Toast
                     int duration = Toast.LENGTH_LONG;

--- a/app/src/main/java/de/opencyclecompass/app/android/TrackArchiveActivity.java
+++ b/app/src/main/java/de/opencyclecompass/app/android/TrackArchiveActivity.java
@@ -11,7 +11,7 @@ import android.widget.Toast;
 
 import java.util.ArrayList;
 
-import de.opencyclecompass.app.android.storage.OcycoTrack;
+import de.opencyclecompass.app.android.storage.OcycoTrackMetadata;
 import de.opencyclecompass.app.android.util.Utils;
 
 /**
@@ -39,9 +39,8 @@ public class TrackArchiveActivity extends AppCompatActivity {
                     Toast.makeText(getApplicationContext(), "Upload Track ...",
                             Toast.LENGTH_LONG).show();
                     Intent intent = new Intent(getApplicationContext(), UploadTrackActivity.class);
-                    intent.putExtra("track", OcycoApplication.trackArchive.getTrackMetadataMap().get(
-                            OcycoApplication.trackArchive.getTrackUuidList().get(position)
-                    ).getUuid().toString());
+                    intent.putExtra("track", OcycoApplication.trackArchive.getTrackUuidList()
+                            .get(position).toString());
                     intent.putExtra("fromArchive", true);
                     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                     startActivity(intent);
@@ -61,7 +60,7 @@ public class TrackArchiveActivity extends AppCompatActivity {
     private void updateUI() {
         arrayList.clear();
 
-        for (OcycoTrack.MetaData metadata : OcycoApplication.trackArchive.getTrackMetadataList()) {
+        for (OcycoTrackMetadata metadata : OcycoApplication.trackArchive.getTrackMetadataList()) {
             if (metadata != null) {
                 arrayList.add(Utils.getDateTime(metadata.getStartTime()));
             }
@@ -79,5 +78,6 @@ public class TrackArchiveActivity extends AppCompatActivity {
      */
     public void onClickTrackArchiveDeleteAll(View view) {
         OcycoApplication.trackArchive.deleteAll();
+        updateUI();
     }
 }

--- a/app/src/main/java/de/opencyclecompass/app/android/TrackArchiveActivity.java
+++ b/app/src/main/java/de/opencyclecompass/app/android/TrackArchiveActivity.java
@@ -62,7 +62,12 @@ public class TrackArchiveActivity extends AppCompatActivity {
         arrayList.clear();
 
         for (OcycoTrack.MetaData metadata : OcycoApplication.trackArchive.getTrackMetadataList()) {
-            arrayList.add(Utils.getDateTime(metadata.getStartTime()));
+            if (metadata != null) {
+                arrayList.add(Utils.getDateTime(metadata.getStartTime()));
+            }
+            else {
+                arrayList.add("Fehler :-(");
+            }
         }
 
         adapter.notifyDataSetChanged();

--- a/app/src/main/java/de/opencyclecompass/app/android/Tracking.java
+++ b/app/src/main/java/de/opencyclecompass/app/android/Tracking.java
@@ -56,8 +56,8 @@ public class Tracking extends Service implements LocationListener, OnConnectionF
         if (checkAccuracy(location.getAccuracy())) {
             updateDatabase();
             //update Notification
-            int num_rows = track.metaData.getNumberOfLocations();
-            double total_dist = track.metaData.getTotalDistance();
+            int num_rows = track.metadata.getNumberOfLocations();
+            double total_dist = track.metadata.getTotalDistance();
             String s_total_dist = Utils.roundDecimals(total_dist / 1000d);
             // Update notification, if online tracking ist running
             if (OcycoApplication.isOnline_tracking_running()) {
@@ -94,8 +94,8 @@ public class Tracking extends Service implements LocationListener, OnConnectionF
         //only call mathematical methods, if this is not the first location - else there will be a NPE
         if (!mCalculate.checkFirstLoc()) {
             mCalculate.calculateTimeVars(OcycoApplication.gettAnkEingTime());
-            mCalculate.calculateDrivenDistance(track.metaData.getTotalDistance());
-            Log.i(TAG, "sEing tf callCalc " + (track.metaData.getTotalDistance()));
+            mCalculate.calculateDrivenDistance(track.metadata.getTotalDistance());
+            Log.i(TAG, "sEing tf callCalc " + (track.metadata.getTotalDistance()));
             mCalculate.calculateDrivenTime();
             mCalculate.calculateSpeed();
             mCalculate.math(OcycoApplication.isUseTimeFactor(), OcycoApplication.getsEingTimeFactor() / 1000d);
@@ -154,8 +154,9 @@ public class Tracking extends Service implements LocationListener, OnConnectionF
     }
 
     /**
-     * Builds a GoogleApiClient. Uses the {@code #addApi} method to request the
-     * LocationServices API.
+     * Builds a {@link GoogleApiClient}.
+     * Uses the {@link GoogleApiClient.Builder#addApi(com.google.android.gms.common.api.Api)} method to request
+     * the {@link LocationServices} API.
      */
     protected void buildGoogleApiClient() {
         Log.i(TAG, "buildGoogleApiClient()");
@@ -201,7 +202,7 @@ public class Tracking extends Service implements LocationListener, OnConnectionF
         int mNotificationId = 42;
         NotificationManager mNotifyMgr = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
         mNotifyMgr.cancel(mNotificationId);
-        if ((track.metaData.getNumberOfLocations() < 10)
+        if ((track.metadata.getNumberOfLocations() < 10)
                 || !track.removeRandomStartEnd()) {
             // don't upload empty or too short track
             Toast.makeText(this, getString(R.string.upload_track_error_too_short),
@@ -211,7 +212,7 @@ public class Tracking extends Service implements LocationListener, OnConnectionF
         else {
             OcycoApplication.trackArchive.add(track);
             Intent intent = new Intent(this, UploadTrackActivity.class);
-            intent.putExtra("track", track.metaData.getUuid().toString());
+            intent.putExtra("track", track.metadata.getUuid().toString());
             intent.putExtra("fromArchive", false);
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             startActivity(intent);

--- a/app/src/main/java/de/opencyclecompass/app/android/UploadTrackActivity.java
+++ b/app/src/main/java/de/opencyclecompass/app/android/UploadTrackActivity.java
@@ -134,9 +134,9 @@ public class UploadTrackActivity extends AppCompatActivity {
     private void initUI() {
 
         editText_UploadTrackDuration.setText(
-              Utils.formatTime(track.metaData.getDuration()));
+              Utils.formatTime(track.metadata.getDuration()));
         editText_UploadTrackLength.setText(
-              String.format("%s km", Utils.roundDecimals(track.metaData.getTotalDistance()/1000.0)));
+              String.format("%s km", Utils.roundDecimals(track.metadata.getTotalDistance()/1000.0)));
         uploadPublic = prefs.getBoolean("upload_public", false);
         token = prefs.getString("upload_token", null);
         if (token == null) {
@@ -298,7 +298,7 @@ public class UploadTrackActivity extends AppCompatActivity {
     private String makeUrl() {
         String lurlstr;
         Uri.Builder lurl;
-        lurl = Uri.parse(this.getString(R.string.api1_base_url) + this.getString(R.string.api1_pushtrack_new)).buildUpon().appendQueryParameter("duration", Long.toString(track.metaData.getDuration())).appendQueryParameter("length", Double.toString(track.metaData.getTotalDistance())).appendQueryParameter("user_token", token);
+        lurl = Uri.parse(this.getString(R.string.api1_base_url) + this.getString(R.string.api1_pushtrack_new)).buildUpon().appendQueryParameter("duration", Long.toString(track.metadata.getDuration())).appendQueryParameter("length", Double.toString(track.metadata.getTotalDistance())).appendQueryParameter("user_token", token);
         if (uploadPublic) {
             lurl.appendQueryParameter("name", editText_UploadTrackName.getText().toString()).appendQueryParameter("comment", editText_UploadTrackCom.getText().toString()).appendQueryParameter("public", "true");
         } else {
@@ -490,7 +490,7 @@ public class UploadTrackActivity extends AppCompatActivity {
                             notification = "Track \"" + track_id + "\" mit " + nodes_s + " GPS-Koordinaten erstellt am " + created_s;
 
                             // mark track in track archive as uploaded
-                            track.metaData.setUploaded(true);
+                            track.metadata.setUploaded(true);
                             OcycoApplication.trackArchive.update(trackUuid);
                         } else if (json.has("error")) {
                             notification = getString(R.string.error) + json.getString("error");

--- a/app/src/main/java/de/opencyclecompass/app/android/storage/OcycoTrackArchive.java
+++ b/app/src/main/java/de/opencyclecompass/app/android/storage/OcycoTrackArchive.java
@@ -294,6 +294,7 @@ public class OcycoTrackArchive {
         ObjectInputStream input;
         ObjectInputStream inputMetadata;
         String filename = trackUuid.toString() + FILE_EXTENSION;
+        String filenameMetadata = trackUuid.toString() + FILE_EXTENSION_META;
         try {
             input = new ObjectInputStream(
                     new FileInputStream(
@@ -307,7 +308,7 @@ public class OcycoTrackArchive {
             //  metadata field
             inputMetadata = new ObjectInputStream(
                     new FileInputStream(
-                            new File(new File(context.getFilesDir(),"")+ File.separator+filename)
+                            new File(new File(context.getFilesDir(),"")+ File.separator+filenameMetadata)
                     )
             );
             OcycoTrack.MetaData metadata = (OcycoTrack.MetaData) inputMetadata.readObject();

--- a/app/src/main/java/de/opencyclecompass/app/android/storage/OcycoTrackMetadata.java
+++ b/app/src/main/java/de/opencyclecompass/app/android/storage/OcycoTrackMetadata.java
@@ -1,0 +1,112 @@
+package de.opencyclecompass.app.android.storage;
+
+import java.util.UUID;
+
+/**
+ * OcycoTrackMetadata contains the metadata for one {@link OcycoTrack}
+ * (totalDistance, startTime, duration, numberOfLocations, uuid, publicId, uploaded)
+ */
+public class OcycoTrackMetadata {
+    public static final long PUBLIC_ID_INVALID = -1L;
+
+    protected double totalDistance;
+    protected long startTime;
+    protected long duration;
+    protected int numberOfLocations;
+
+    protected UUID uuid;
+    protected long publicId;
+    protected boolean uploaded;
+
+    /**
+     * default constructor, generates a new (random) {@link UUID}, sets startTime to the current time and
+     * publicId to {@link #PUBLIC_ID_INVALID}
+     */
+    public OcycoTrackMetadata() {
+        startTime = System.currentTimeMillis();
+        uuid = UUID.randomUUID();
+        publicId = PUBLIC_ID_INVALID;
+        totalDistance = 0.0;
+    }
+
+    /**
+     * constructor to restore an {@link OcycoTrackMetadata} object from the SQLite database
+     * @param totalDistance totalDistance
+     * @param startTime startTime
+     * @param duration duration
+     * @param numberOfLocations numberOfLocations
+     * @param uuid uuid
+     * @param publicId publicId
+     * @param uploaded uploaded
+     */
+    public OcycoTrackMetadata(double totalDistance,
+                              long startTime,
+                              long duration,
+                              int numberOfLocations,
+                              UUID uuid,
+                              long publicId,
+                              boolean uploaded) {
+        this.totalDistance = totalDistance;
+        this.startTime = startTime;
+        this.duration = duration;
+        this.numberOfLocations = numberOfLocations;
+        this.uuid = uuid;
+        this.publicId = publicId;
+        this.uploaded = uploaded;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public long getPublicId() {
+        return publicId;
+    }
+
+    public boolean hasPublicId() {
+        return (publicId != PUBLIC_ID_INVALID);
+    }
+
+    /**
+     * @return timestamp of track start
+     */
+    public long getStartTime() {
+        return startTime;
+    }
+
+    /**
+     * Get total distance of track in meter
+     *
+     * You can to recalculate distances between locations using {@link OcycoTrack#recalculateDistances()}
+     * before using this method to get a more precise result.
+     *
+     * The total distance is calculated on each modification made to the location list
+     *
+     * @return total distance of track in meter
+     */
+    public double getTotalDistance() {
+        return totalDistance;
+    }
+
+    /**
+     * @return number of locations in track
+     */
+    public int getNumberOfLocations() {
+        return numberOfLocations;
+    }
+
+    /**
+     * @return duration of track in milliseconds or -1 if track is empty
+     */
+    public long getDuration() {
+        return duration;
+    }
+
+    public boolean isUploaded() {
+        return uploaded;
+    }
+
+    public void setUploaded(boolean uploaded) {
+        this.uploaded = uploaded;
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,7 +101,8 @@
     <string name="stop_tracking">Tracking stoppen</string>
     <string name="track_archive">Track Archiv (Später Hochladen)</string>
     <string name="track_archive_delete">Track Archiv löschen</string>
-    <string name="track_archive_corrupt">Interner Fehler: Die archivierten Tracks sind beschädigt.</string>
+    <string name="track_archive_error_reading_file">Interner Fehler: Die archivierten Tracks sind beschädigt.</string>
+    <string name="track_archive_error_reading_array">Interner Fehler: Lesen des archivierten Tracks nicht möglich. Datei ist beschädigt.</string>
     <string name="start_from_current_position">Von aktueller Position aus navigieren</string>
     <string name="search_position">Position wird gesucht...</string>
     <string name="switch_timeFactor">Möchten Sie für die Berechnung der Ankunftszeit die gesammelten Daten anderer User nutzen?</string>


### PR DESCRIPTION
### Track archive: rewrite finished
- track archive stores metadata in a SQLite database
- only the list of OcycoLocations is stored in a file (using serialization)
- de-serialized data is checked for consistency, errors get toasted
- OcycoTrackMetadata replace OcycoTrack.MetaData and is now an independent class
- OcycoTrack.metaData renamed to OcycoTrack.metadata
- javadoc supplemented

**Warning**: This breaks backward compatibility and makes stored tracks unusable.
